### PR TITLE
Revert Flip change and update MRA for core rotation.

### DIFF
--- a/releases/Shot Rider (B-Board 89624B-1).mra
+++ b/releases/Shot Rider (B-Board 89624B-1).mra
@@ -27,7 +27,7 @@
 	<buttons>3</buttons>
 	<buttons default="A,B,Start,Select,R" names="Gas,Brake,Start 1P,Start 2P,Coin"></buttons>
 
-	<switches default="FF,FF,00">
+	<switches default="FF,FE,00">
 		<dip bits="0,2" ids="5 Coins/1 Credit,1c/5cr,3c/1cr,1c/2cr,4 Coins/1 Credit,1c/3cr,2c/1cr,1c/1cr" name="Coin A"></dip>
 		<dip bits="3,4" ids="3c/1cr,1c/2cr,2c/1cr,1c/1cr" name="Coin B"></dip>
 		<dip bits="5" ids="On,Off" name="Unknown"></dip>

--- a/releases/Shot Rider (B-Board 89624B-1).mra
+++ b/releases/Shot Rider (B-Board 89624B-1).mra
@@ -18,7 +18,7 @@
 	<about></about>
 
 	<resolution>15kHz</resolution>
-	<rotation>vertical (ccw)</rotation>
+	<rotation>vertical (cw)</rotation>
 	<flip>yes</flip>
 
 	<players>2 (alternating)</players>

--- a/releases/Traverse USA- Zippy Race (US).mra
+++ b/releases/Traverse USA- Zippy Race (US).mra
@@ -28,7 +28,7 @@
 	<num_buttons>2</num_buttons>
 	<buttons default="A,B,Start,Select,R" names="Gas,Brake,Start 1P,Start 2P,Coin"></buttons>
 
-	<switches default="FF,FF,00">
+	<switches default="FF,FE,00">
 		<dip bits="0,1" ids="Max,Hi,Med,Low" name="Fuel Redcd on Collsn"></dip>
 		<dip bits="2" ids="Hi,Low" name="Fuel Consumption"></dip>
 		<dip bits="3" ids="Yes,No" name="Allow Continue"></dip>

--- a/releases/Traverse USA- Zippy Race (US).mra
+++ b/releases/Traverse USA- Zippy Race (US).mra
@@ -19,7 +19,7 @@
 	<about></about>
 
 	<resolution>15kHz</resolution>
-	<rotation>vertical (ccw)</rotation>
+	<rotation>vertical (cw)</rotation>
 	<flip>yes</flip>
 
 	<players>2 (alternating)</players>


### PR DESCRIPTION
The change I made last night made the video over HDMI be upside down. Rather than try to do any more flip nonsense, I'm reverting that change and updating the MRAs to match the core output.